### PR TITLE
Added functionality to the driver

### DIFF
--- a/ds90ub954.h
+++ b/ds90ub954.h
@@ -1173,6 +1173,9 @@ struct ds90ub953_priv {
 	int i2c_pt; // i2c-pass-through-all
 	enum i2c_strap_mode i2c_strap_mode; 
 
+	int aeq_min;
+	int aeq_max;
+
 	int initialized;
 
 	int gpio0_oe; // gpio0_output_enable

--- a/ds90ub954.h
+++ b/ds90ub954.h
@@ -852,7 +852,10 @@
 
 #define TI953_REG_LOCAL_GPIO_DATA 0x0d
 #define TI953_GPIO_OUT_SRC        0
-#define TI953_GPIO_RMTEN          4
+#define TI953_GPIO0_RMTEN         4
+#define TI953_GPIO1_RMTEN         5
+#define TI953_GPIO2_RMTEN         6
+#define TI953_GPIO3_RMTEN         7
 
 #define TI953_REG_GPIO_CTRL  0x0e
 #define TI953_GPIO0_INPUT_EN 0
@@ -1146,6 +1149,15 @@
 #define NUM_SERIALIZER 2
 #define NUM_ALIAS 8
 
+/*
+ * I2C mode can be overridden or left as strapped.
+ */
+enum i2c_strap_mode {
+	STRAP_MODE_OVERRIDE_3V3,
+	STRAP_MODE_OVERRIDE_1V8,
+	STRAP_MODE_NO_OVERRIDE,
+};
+
 struct ds90ub953_priv {
 	struct i2c_client *client;
 	struct regmap *regmap;
@@ -1159,6 +1171,7 @@ struct ds90ub953_priv {
 	int i2c_alias[NUM_ALIAS]; // array with the i2c alias addresses
 	int conts_clk; // continuous clock (0: discontinuous, 1: continuous)
 	int i2c_pt; // i2c-pass-through-all
+	enum i2c_strap_mode i2c_strap_mode; 
 
 	int initialized;
 

--- a/ti,ds90ub954.txt
+++ b/ti,ds90ub954.txt
@@ -46,6 +46,13 @@ Boolean:
 - test-pattern          Enables test pattern
 - i2c-pass-through-all  Enable all i2c messages to be forwarded over FPD-Link III
 
+String:
+- i2c-strap-mode        Optionally override the I2C voltage level setting from
+                        the strapped IDX pin. No override if not set.
+                        Possible values:
+                        - strapped       leave as strapped
+                        - 3v3            set to 3.3V
+                        - 1v8            set to 1.8V
 
 /*------------------------------------------------------------------------------
 * Virtual-channel mapping
@@ -82,19 +89,16 @@ The following device tree parameters can be used to set the GPIO control:
 
 Possible GPIO control values are:
 
-    0    connects the GPIO to GPIO0 (input) of deserializer
-    1    connects the GPIO to GPIO1 (input) of deserializer
-    2    connects the GPIO to GPIO2 (input) of deserializer
+    0    connects the GPIO to GPIO0 (input/output) of deserializer
+    1    connects the GPIO to GPIO1 (input/output) of deserializer
+    2    connects the GPIO to GPIO2 (input/output) of deserializer
     3    NOT SUPPORTED - connects the GPIO to GPIO3 of deserializer 
-    4    connects the GPIO to GPIO4 (input) of deserializer
-    5    connects the GPIO to GPIO5 (input) of deserializer
-    6    connects the GPIO to GPIO6 (input) of deserializer
+    4    connects the GPIO to GPIO4 (input/output) of deserializer
+    5    connects the GPIO to GPIO5 (input/output) of deserializer
+    6    connects the GPIO to GPIO6 (input/output) of deserializer
     8    output constant value of 0
     9    output constant value of 1
     10   frameSync signal
-
-(Deserializer GPIO's set as output is not supported as device tree option. Driver
-must be edited if the deserializer GPIO's are needed as output.)
 
 /*------------------------------------------------------------------------------
 * Serializer CLK_OUT (in synchronized mode)

--- a/ti,ds90ub954.txt
+++ b/ti,ds90ub954.txt
@@ -40,6 +40,8 @@ Integer values:
 - csi-lane-count        Number of CSI lanes             default value: 4
 - i2c-address           I2C address of serializer       default value: 0x18
                         (this address can be chosen freely)
+- aeq-min               AEQ start value                 default value: 2
+- aeq-max               AEQ max value                   default value: 15
 
 Boolean:
 - continuous-clock      Enables continuous clock


### PR DESCRIPTION
We have added the following functionality to the driver;
- Serializer GPIO:s usable as inputs.
- I2C voltage level overrideable.
- Set AEQ min/max values.