### PR TITLE
fix rpi-firmware commit hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,34 @@ dtoverlay=imx219
 core_freq_min=250
 ```
 
+To ensure that the imx219 module will load after ds90ub954, add imx219 to the blacklist creating `/etc/modprobe.d/ds90ub954.conf`:
+```bash
+sudo nano /etc/modprobe.d/ds90ub954.conf
+```
+
+Insert the following line into the file:
+
+```bash
+blacklist imx219
+```
+
+Copy script and service files to the correct destinations:
+
+```bash
+sudo cp camera-module-load.sh /lib/systemd/
+sudo cp camera-module-load.service /usr/lib/systemd/system/
+```
+
+Make `/lib/systemd/camera-module-load.sh` executabe:
+```bash
+sudo chmod +x /lib/systemd/camera-module-load.sh
+```
+
+Enable `camera-module-load.service`:
+```bash
+sudo systemctl enable camera-module-load.service
+```
+
 Reboot the RaspberryPi:
 
 ```bash
@@ -101,17 +129,6 @@ If the module was successfully loaded, you should find a video0 device in the `/
 ```bash
 ls /dev/video0
 ```
-
-If the command returns `No such file or directory` then the loading of the imx219 module failed. This can happen when the imx219 sensor model is loaded before the ds90ub954 module has finished setting up the i2c channel. 
-
-This problem can be solved by reloading the imx219 module (has to be done again after every reboot):
-
-```
-sudo modprobe -r imx219
-sudo modprobe imx219
-```
-
-Now `/dev/video0` should exist.
 
 ### Use libcamera to display video stream
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ sudo apt full-upgrade
 After a reboot, execute (if there is an error with an invalid hash, run the first command twice):
 
 ```bash
-sudo rpi-update 655fc658a15ae7a6f37103754adb39ba52a9a14e
+sudo rpi-update b2b3c05f6e9944c2e7eab8648a0cde932e25a31e
 sudo reboot
 ```
 

--- a/camera-module-load.service
+++ b/camera-module-load.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Load camera driver module after ds90ub954
+Requires=systemd-modules-load.service
+After=systemd-modules-load.service
+
+[Service]
+Type=oneshot
+ExecStart=/lib/systemd/camera-module-load.sh /sys/bus/i2c/devices/10-0030/test_pattern_des imx219
+TimeoutSec=10s
+
+[Install]
+WantedBy=multi-user.target

--- a/camera-module-load.sh
+++ b/camera-module-load.sh
@@ -2,7 +2,7 @@
 
 if [ -z "$1" ]
   then
-    echo "No divice file provided"
+    echo "No device file provided"
     exit 1
 fi
 

--- a/camera-module-load.sh
+++ b/camera-module-load.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+  then
+    echo "No divice file provided"
+    exit 1
+fi
+
+while true
+do
+  if [ -e "$1" ];
+    then
+      modprobe "$2"
+      break
+    else
+      sleep 0.1
+    fi
+done

--- a/ds90ub954-imx219-overlay.dts
+++ b/ds90ub954-imx219-overlay.dts
@@ -1,0 +1,58 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2711";
+
+	i2c_frag: fragment@0 {
+		target = <&i2c_csi_dsi>;
+
+		__overlay__ {
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			status = "okay";
+
+			gpio_expander: gpio@38 {
+				compatible = "nxp,pca9534";
+				reg = <0x38>;
+				gpio-controller;
+				#gpio-cells = <0x02>;
+			};
+
+			fpdlink: ds90ub954@30 {
+				compatible = "ti,ds90ub954";
+				reg = <0x30>;
+				status = "okay";
+				csi-lane-count = <0x02>;
+				csi-lane-speed = <0x640>;
+				pdb-gpio  = <&gpio_expander 0x00 0x00>;
+				// pdb-gpios  = <&gpio 22 GPIO_ACTIVE_LOW>;
+				pass-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+				lock-gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+
+				i2c_address_s0: num-alias-pairs-s0 {
+					list-cells = <0x02>;
+				};
+
+				serializers {
+					status = "okay";
+					num-channels = <0x02>;
+
+					serializer@0 {
+						status = "okay";
+						rx-channel = <0x01>;
+						i2c-address = <0x18>;
+						csi-lane-count = <0x02>;
+						gpio0-output-enable = <0x01>;
+						gpio0-control = <0x09>;
+						i2c-slave = <&i2c_address_s0 0x10 0x64>;
+						slave-alias = <&i2c_address_s0 0x10 0x64>;
+					};
+				};
+			};
+		};
+	};
+};

--- a/ds90ub954-imx296-overlay.dts
+++ b/ds90ub954-imx296-overlay.dts
@@ -1,0 +1,58 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "brcm,bcm2711";
+
+	i2c_frag: fragment@0 {
+		target = <&i2c_csi_dsi>;
+
+		__overlay__ {
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+			status = "okay";
+
+			gpio_expander: gpio@38 {
+				compatible = "nxp,pca9534";
+				reg = <0x38>;
+				gpio-controller;
+				#gpio-cells = <0x02>;
+			};
+
+			fpdlink: ds90ub954@30 {
+				compatible = "ti,ds90ub954";
+				reg = <0x30>;
+				status = "okay";
+				csi-lane-count = <0x01>;
+				csi-lane-speed = <0x640>;
+				pdb-gpio  = <&gpio_expander 0x00 0x00>;
+				// pdb-gpios  = <&gpio 22 GPIO_ACTIVE_LOW>;
+				pass-gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+				lock-gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+
+				i2c_address_s0: num-alias-pairs-s0 {
+					list-cells = <0x02>;
+				};
+
+				serializers {
+					status = "okay";
+					num-channels = <0x02>;
+
+					serializer@0 {
+						status = "okay";
+						rx-channel = <0x01>;
+						i2c-address = <0x18>;
+						csi-lane-count = <0x01>;
+						gpio0-output-enable = <0x01>;
+						gpio0-control = <0x00>;
+						i2c-slave = <&i2c_address_s0 0x1a 0x64>;
+						slave-alias = <&i2c_address_s0 0x1a 0x64>;
+					};
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
Invalid commit hash was provided in the README(running command twice as advised did not help):
```sh
pi@raspberrypi:~ $ sudo rpi-update 655fc658a15ae7a6f37103754adb39ba52a9a14e
 *** Raspberry Pi firmware updater by Hexxeh, enhanced by AndrewS and Dom
 *** Performing self-update
 *** Relaunching after update
 *** Raspberry Pi firmware updater by Hexxeh, enhanced by AndrewS and Dom
FW_REV:
BOOTLOADER_REV:72cedfe5eea64bb8509b7d0fec68f5df5dd22f9e
 *** Invalid hash given
```
The correct commit is: https://github.com/raspberrypi/rpi-firmware/commit/b2b3c05f6e9944c2e7eab8648a0cde932e25a31e
