### PR TITLE
Fix module load order

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ dtoverlay=imx219
 core_freq_min=250
 ```
 
+To ensure that the imx219 module will load after ds90ub954, add soft module dependency by creating `/etc/modprobe.d/ds90ub954.conf`:
+```bash
+sudo nano /etc/modprobe.d/ds90ub954.conf
+```
+
+Insert the following line into the file:
+
+```bash
+softdep imx219 pre: ds90ub954
+```
+
+You can verify that imx219 now depends on ds90ub954 by running:
+```bash
+modprobe -D imx219
+```
+
 Reboot the RaspberryPi:
 
 ```bash
@@ -101,17 +117,6 @@ If the module was successfully loaded, you should find a video0 device in the `/
 ```bash
 ls /dev/video0
 ```
-
-If the command returns `No such file or directory` then the loading of the imx219 module failed. This can happen when the imx219 sensor model is loaded before the ds90ub954 module has finished setting up the i2c channel. 
-
-This problem can be solved by reloading the imx219 module (has to be done again after every reboot):
-
-```
-sudo modprobe -r imx219
-sudo modprobe imx219
-```
-
-Now `/dev/video0` should exist.
 
 ### Use libcamera to display video stream
 


### PR DESCRIPTION
Instead of reloading the imx219 module manually in case of imx219 loaded before ds90ub954 it is possible to create a soft dependency to fix the load order.